### PR TITLE
Obs lost

### DIFF
--- a/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
+++ b/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
@@ -319,15 +319,28 @@ private:
       for (int i = 0; i < (int)tracked_obstacles_.size(); i++) {
   
         // printf("obstacle %i, linvel: %.3f\n", i, linvel);
+        rclcpp::Time tStamp_fixed(tracked_obstacles_[i].tStamp, now_time.get_clock_type());
+
         auto now_time = this->get_clock()->now();
         double now_seconds = now_time.seconds();
         double tStamp_seconds = tracked_obstacles_[i].tStamp.seconds();
 
         if (now_seconds - tStamp_seconds < track_timeout_) { //&& linvel >= min_vel_tracked_
           temp.push_back(tracked_obstacles_[i]);
+        }else{ 
+          if (!tracked_obstacles_[i].isLost) {
+            tracked_obstacles_[i].lostTime = now_time;
+            tracked_obstacles_[i].isLost = true;
+          }
+          rclcpp::Time lostTime_fixed(tracked_obstacles_[i].lostTime, now_time.get_clock_type());
+
+          double lost_seconds = (now_time - tracked_obstacles_[i].lostTime).seconds();
+          if (lost_seconds < 3.0) {
+            RCLCPP_ERROR(this->get_logger(),"Obj perdido: %d: %f", i, lost_seconds);
+            temp.push_back(tracked_obstacles_[i]);
+          }
         }
       }
-
       tracked_obstacles_.clear();
       tracked_obstacles_ = temp;
   

--- a/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
+++ b/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
@@ -288,7 +288,6 @@ private:
           // Update the filter
           tracked_obstacles_[i].update(obs[k].center.x, obs[k].center.y, posDev,
                                        this->get_clock()->now() );
-  
           // Mark the detection as used
           used[k] = true;
           // std::cout << "Done" << std::endl;
@@ -308,7 +307,6 @@ private:
           tracked_obstacles_.push_back(obstacle);
           // std::cout << "New obstacle added! size: " <<
           // tracked_obstacles_.size() << std::endl;
-  
           used[i] = true;
         }
       }
@@ -318,9 +316,6 @@ private:
 
       for (int i = 0; i < (int)tracked_obstacles_.size(); i++) {
   
-        // printf("obstacle %i, linvel: %.3f\n", i, linvel);
-        rclcpp::Time tStamp_fixed(tracked_obstacles_[i].tStamp, now_time.get_clock_type());
-
         auto now_time = this->get_clock()->now();
         double now_seconds = now_time.seconds();
         double tStamp_seconds = tracked_obstacles_[i].tStamp.seconds();
@@ -328,13 +323,7 @@ private:
         if (now_seconds - tStamp_seconds < track_timeout_) { //&& linvel >= min_vel_tracked_
           temp.push_back(tracked_obstacles_[i]);
         }else{ 
-          if (!tracked_obstacles_[i].isLost) {
-            tracked_obstacles_[i].lostTime = now_time;
-            tracked_obstacles_[i].isLost = true;
-          }
-          rclcpp::Time lostTime_fixed(tracked_obstacles_[i].lostTime, now_time.get_clock_type());
-
-          double lost_seconds = (now_time - tracked_obstacles_[i].lostTime).seconds();
+          double lost_seconds = (now_seconds - tStamp_seconds);
           if (lost_seconds < 3.0) {
             RCLCPP_ERROR(this->get_logger(),"Obj perdido: %d: %f", i, lost_seconds);
             temp.push_back(tracked_obstacles_[i]);

--- a/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
+++ b/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
@@ -331,7 +331,6 @@ private:
           if(keep_obstacle_){
             double lost_seconds = (now_seconds - tStamp_seconds);
             if (lost_seconds < time_to_keep_obstacle_) {
-              RCLCPP_ERROR(this->get_logger(),"Obj perdido: %d: %f", i, lost_seconds);
               temp.push_back(tracked_obstacles_[i]);
             }
           }

--- a/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
+++ b/dynamic_obstacles/src/dynamic_obstacle_detector.cpp
@@ -327,13 +327,8 @@ private:
 
         if (now_seconds - tStamp_seconds < track_timeout_) { //&& linvel >= min_vel_tracked_
           temp.push_back(tracked_obstacles_[i]);
-        }else{ 
-          if(keep_obstacle_){
-            double lost_seconds = (now_seconds - tStamp_seconds);
-            if (lost_seconds < time_to_keep_obstacle_) {
-              temp.push_back(tracked_obstacles_[i]);
-            }
-          }
+        }else if (keep_obstacle_ && (now_seconds - tStamp_seconds) < time_to_keep_obstacle_) {
+          temp.push_back(tracked_obstacles_[i]);
         }
       }
       tracked_obstacles_.clear();

--- a/dynamic_obstacles/src/obstacle_kf.hpp
+++ b/dynamic_obstacles/src/obstacle_kf.hpp
@@ -20,9 +20,11 @@ struct ObstacleKF
 	std::string name;
 	
 	// Last time update
+	rclcpp::Time lostTime;
 	rclcpp::Time tStamp;
 	
 	// Updated flag
+	bool isLost; 
 	bool updated;
 
 	// number of detections

--- a/dynamic_obstacles/src/obstacle_kf.hpp
+++ b/dynamic_obstacles/src/obstacle_kf.hpp
@@ -20,11 +20,9 @@ struct ObstacleKF
 	std::string name;
 	
 	// Last time update
-	rclcpp::Time lostTime;
 	rclcpp::Time tStamp;
 	
 	// Updated flag
-	bool isLost; 
 	bool updated;
 
 	// number of detections


### PR DESCRIPTION
# Mudanças

- Adicionado um tempo para o obstáculo quando ele é perdido. Esse tempo é declarado no launch do `officebot_nav` como `time_keep_obstacles_`.
- Adicionado um parâmetro booleano para definir se os pontos perdidos devem ser considerados pelo tempo estabelecido: `keep_obstacle`.

# Mudanças em parâmetros

- Todas as mudanças foram feitas no `officebot_nav`, PR: https://github.com/socialdroids/officebot_nav/pull/3
